### PR TITLE
[Squad JSR] PJR-120 - Webhook - 1.3.0-rc.2: Proposta para criar header para identificação de Authorization Server

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6,7 +6,7 @@ info:
 
     Informações sobre endpoints suportados e funcionamento podem ser encontrados na página <a href="https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/105021661/Conven+o+de+Webhook">Convenção de Webhook</a>, disponível no portal do desenvolvedor do Open Finance Brasil.
     
-  version: 1.3.0-rc.1
+  version: 1.3.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -81,6 +81,7 @@ paths:
         - $ref: '#/components/parameters/enrollmentId'
         - $ref: '#/components/parameters/versionApi'
         - $ref: '#/components/parameters/EnrollmentxWebhookInteractionId'
+        - $ref: '#/components/parameters/XAuthorizationServerId'
       requestBody:
         content:
           application/json:
@@ -281,6 +282,14 @@ components:
         pattern: '^[a-zA-Z0-9][a-zA-Z0-9\-]{0,99}$'
         minLength: 1
         maxLength: 100
+    XAuthorizationServerId:
+      name: x-authorization-server-id
+      in: header
+      description: Identificador único do Authorization Server.
+      required: true
+      schema:
+        type: string
+        example: '123e4567-e89b-12d3-a456-426614174000'
   responses:
     202Webhook:
       description: Requisição aceita para processamento posterior.


### PR DESCRIPTION
### Contexto
Atualmente, o Open Finance Brasil disponibiliza a API Webhook, que permite a notificação entre produtos

A segurança é garantida por meio de mTLS e registro de URL de callback no diretório de participantes, vinculada ao Software Client via DCR/DCM ▪ Cada Software Client pode cadastrar apenas uma URL de Webhook

Entretanto, organizações com vários Authorization Servers (marcas) não possibilitam ao Software Client identificar de forma precisa qual servidor originou a requisição, pois não há mecanismo de validação

### Descrição

Adicionar um header x-authorization-server-id na requisição, que traga o identificador único do Authorization Server na mensagem enviada pelo Webhook nas notificações relacionadas ao enrollment, conforme detalhes abaixo: 
– nome: x-authorization-server-id 
– obrigatório: sim 
– type: string 
– exemplo: 6df11d0b-a8cb-4d50-b75d-eb65ac35eb26
 – description: “Identificador único do authorization server”