### PR TITLE
[GT de Serviços] PSV-359 - Webhook - 1.3.0: Proposta para adicionar possibilidade de notificações via Webhook na mudança de valor em campos editáveis do consentimento para a API Pagamentos automáticos

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6,7 +6,7 @@ info:
 
     Informações sobre endpoints suportados e funcionamento podem ser encontrados na página <a href="https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/105021661/Conven+o+de+Webhook">Convenção de Webhook</a>, disponível no portal do desenvolvedor do Open Finance Brasil.
     
-  version: 1.3.0-rc.2
+  version: 1.3.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -86,7 +86,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestBodyWebhookEnrollments'
+              $ref: '#/components/schemas/RequestBodyWebhookEvents'
         description: Payload enviado para notificar a alteração no estado do vínculo.
         required: true
       responses:
@@ -107,7 +107,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestBodyWebhook'
+              $ref: '#/components/schemas/RequestBodyWebhookEvents'
         description: Payload enviado para notificar a alteração na entidade do consentimento de longa duração.
         required: true
       responses:
@@ -136,7 +136,7 @@ paths:
           $ref: '#/components/responses/202WebhookPayments'
 components:
   schemas:
-    RequestBodyWebhookEnrollments:
+    RequestBodyWebhookEvents:
       type: object
       required:
         - data


### PR DESCRIPTION
### Contexto
▪ Dada a evolução das APIs e das jornadas de experiência dos usuários, GT Serviços entende necessário habilitar notificações, via Webhook, que tratem de alterações em valores de campos e não apenas na máquina de estado (modelo atual)  
   – Sendo assim, faz-se necessário adicionar documentação relativa ao que deve ser notificado e em qual condição  
▪ Por haver a adição de um novo comportamento, GT também entende necessário discutir nova versão da API Webhook para contemplar esta proposta

### Descrição
Definir nova regra de notificação: Serviços  
– Além dos estados, notificar sobre os campos do consentimento que podem ser editados apenas no detentor.
▪ Ajustar documentação da página “Webhook -> informações gerais -> Endpoints suportados -> Pagamentos  automáticos”, na área do desenvolvedor, inserindo o texto abaixo:  
– Condicionalidades para disparo de eventos em mudança de valor de campos editáveis do consentimento  
             ▫ Campos editáveis apenas na detentora de pagamentos devem ser notificados ao ITP, através do Webhook,   
                sempre que possível.  
- Os campos editáveis apenas no detentor para os produtos Pix Automático e Transferências Inteligentes podem ser encontrados na área de informações gerais da versão corrente da API.  
- 
▪ Alterar o corpo de requisição do endpoint POST ​/automatic-payments​/{versionApi}​/recurring-consents​/{recurringConsentId}, adicionando o novo campo:  
– Chave: eventType  
– Tipo: ENUM  
– Domínio: [STATUS_CHANGED, DATA_CHANGED]  
– Descrição: Tipo de evento que responsável pelo disparo da notificação  